### PR TITLE
Moving queries specific to PgSql to the db class

### DIFF
--- a/src/Databases/DatabaseInterface.ts
+++ b/src/Databases/DatabaseInterface.ts
@@ -14,4 +14,28 @@ export default interface DatabaseInterface {
 	sequence<T>(
 		sequence: (sequenceDb: DatabaseInterface) => Promise<T>,
 	): Promise<T>;
+
+	/**
+	 * The insertAndGet method takes a standard INSERT query,
+	 * executes and returns either an auto-generated id or
+	 * the entire inserted record. Since this is database-dependent,
+	 * the repository handles both cases, but it is better
+	 * to return the record whenever possible, otherwise
+	 * an additional query will have to be performed by the repository
+	 * to retrieve the data.
+	 * The provided query should not contain any delimiter (like a semicolon) at the end
+	 * The returned value is either an array of inserted ids (integers), uuids (strings) or the whole updated records.
+	 */
+	insertAndGet(standardInsertQuery: SqlQuery): Promise<number[]|string[]|any[]>;
+
+	/**
+	 * The updateAndGet method takes a standard UPDATE query and,
+	 * if possible, returns the record returned by the database.
+	 * If it is not possible, the repository will handle the
+	 * null value by performing an additional query.
+	 * The provided query should not contain any delimiter (like a semicolon) at the end
+	 * The returned value is either null (no data about the result) or the whole updated records.
+	 * This method is expected to reject the promise (throw an async exception) is no rows have been updated.
+	 */
+	updateAndGet(standardUpdateQuery: SqlQuery): Promise<null|any[]>;
 };

--- a/src/Databases/PgSqlDatabase.test.ts
+++ b/src/Databases/PgSqlDatabase.test.ts
@@ -219,4 +219,88 @@ describe('PgSqlDatabase', async function() {
 		const results = await db.query(sql`SELECT * FROM "TestMigration";`);
 		expect(results.length).toBe(0);
 	});
+
+	it('insertAndGet - inserting one row', async function() {
+		await db.query(sql`
+			DROP TABLE IF EXISTS "TestInsert";
+			CREATE TABLE "TestInsert" ("id" SERIAL, "text" TEXT NOT NULL);
+		`);
+
+		const result = await db.insertAndGet(sql`
+			INSERT INTO "TestInsert" VALUES (DEFAULT, 'test')
+		`);
+
+		expect(result).toEqual([
+			{
+				id: 1,
+				text: 'test',
+			},
+		]);
+	});
+	it('insertAndGet - inserting multiple rows', async function() {
+		await db.query(sql`
+			DROP TABLE IF EXISTS "TestInsert";
+			CREATE TABLE "TestInsert" ("id" SERIAL, "text" TEXT NOT NULL);
+		`);
+
+		const result = await db.insertAndGet(sql`
+			INSERT INTO "TestInsert" VALUES
+			(DEFAULT, 'test 1'),
+			(DEFAULT, 'test 2')
+		`);
+
+		expect(result).toEqual([
+			{
+				id: 1,
+				text: 'test 1',
+			}, {
+				id: 2,
+				text: 'test 2',
+			},
+		]);
+	});
+
+	it('updateAndGet - updating one row', async function() {
+		await db.query(sql`
+			DROP TABLE IF EXISTS "TestUpdate";
+			CREATE TABLE "TestUpdate" ("id" INTEGER, "text" TEXT NOT NULL);
+			INSERT INTO "TestUpdate" VALUES (1, 'test 1');
+		`);
+
+		const result = await db.updateAndGet(sql`
+			UPDATE "TestUpdate"
+			SET "text" = 'test 2'
+			WHERE "id" = 1
+		`);
+
+		expect(result).toEqual([
+			{
+				id: 1,
+				text: 'test 2',
+			},
+		]);
+	});
+	it('updateAndGet - updating multiple rows', async function() {
+		await db.query(sql`
+			DROP TABLE IF EXISTS "TestUpdate";
+			CREATE TABLE "TestUpdate" ("id" INTEGER, "text" TEXT NOT NULL);
+			INSERT INTO "TestUpdate" VALUES (1, 'test 1');
+			INSERT INTO "TestUpdate" VALUES (2, 'test 2');
+		`);
+
+		const result = await db.updateAndGet(sql`
+			UPDATE "TestUpdate"
+			SET "text" = 'test'
+		`);
+
+		expect(result).toEqual([
+			{
+				id: 1,
+				text: 'test',
+			}, {
+				id: 2,
+				text: 'test',
+			},
+		]);
+	});
 });

--- a/src/Databases/PgSqlDatabase.ts
+++ b/src/Databases/PgSqlDatabase.ts
@@ -86,4 +86,18 @@ export default class PgSqlDatabase implements DatabaseInterface {
 			});
 		}
 	}
+
+	async insertAndGet(standardInsertQuery: SqlQuery): Promise<number[]|string[]|any[]> {
+		return this.query(sql`
+			${standardInsertQuery}
+			RETURNING *;
+		`);
+	}
+
+	async updateAndGet(standardUpdateQuery: SqlQuery): Promise<null|any[]> {
+		return this.query(sql`
+			${standardUpdateQuery}
+			RETURNING *;
+		`);
+	}
 }

--- a/src/Repositories/CrudRepository.ts
+++ b/src/Repositories/CrudRepository.ts
@@ -96,73 +96,75 @@ export default class CrudRepository<Model, ValidAttributes = any, PrimaryKeyType
 	}
 
 	public async create(attributes: Required<ValidAttributes>): Promise<Model> {
-		const entries = Object.entries(attributes);
-		const fields = entries.map(([key, _]: [string, any]) => sql`${new QueryIdentifier(key)}`);
-		const values = entries.map(([_, val]: [string, any]) => sql`${val}`);
+		return this.database.sequence(async (sequenceDb: DatabaseInterface): Promise<Model> => {
+			const entries = Object.entries(attributes);
+			const fields = entries.map(([key, _]: [string, any]) => sql`${new QueryIdentifier(key)}`);
+			const values = entries.map(([_, val]: [string, any]) => sql`${val}`);
 
-		const data = (await this.database.insertAndGet(sql`
-			INSERT INTO ${new QueryIdentifier(this.table)} (${SqlQuery.join(fields, sql`, `)})
-			VALUES (${SqlQuery.join(values, sql`, `)})
-		`))[0];
+			const data = (await sequenceDb.insertAndGet(sql`
+				INSERT INTO ${new QueryIdentifier(this.table)} (${SqlQuery.join(fields, sql`, `)})
+				VALUES (${SqlQuery.join(values, sql`, `)})
+			`))[0];
 
-		if (typeof data === 'string' || typeof data === 'number') {
-			// TODO need a sequence between those queries
-			const results = await this.database.query(sql`
-				SELECT *
-				FROM ${new QueryIdentifier(this.table)}
-				WHERE ${new QueryIdentifier(this.primaryKey)} = ${data};
-			`);
+			if (typeof data === 'string' || typeof data === 'number') {
+				const results = await sequenceDb.query(sql`
+					SELECT *
+					FROM ${new QueryIdentifier(this.table)}
+					WHERE ${new QueryIdentifier(this.primaryKey)} = ${data};
+				`);
 
-			if (results.length === 0) {
-				throw new NotFoundError(`Object not found in table ${this.table} after insert (got ${this.primaryKey} = ${data})`);
+				if (results.length === 0) {
+					throw new NotFoundError(`Object not found in table ${this.table} after insert (got ${this.primaryKey} = ${data})`);
+				}
+
+				return this.createModelFromAttributes(results[0]);
+			} else {
+				return this.createModelFromAttributes(data);
 			}
-
-			return this.createModelFromAttributes(results[0]);
-		} else {
-			return this.createModelFromAttributes(data);
-		}
+		});
 	}
 
 	public async update(model: Model, attributes: Partial<ValidAttributes>): Promise<Model> {
-		const fieldQueries = Object.entries(attributes).map(
-			([key, value]: [string, any]) => (
-				sql`${new QueryIdentifier(key)} = ${value}`
-			)
-		);
+		return this.database.sequence(async (sequenceDb: DatabaseInterface): Promise<Model> => {
+			const fieldQueries = Object.entries(attributes).map(
+				([key, value]: [string, any]) => (
+					sql`${new QueryIdentifier(key)} = ${value}`
+				)
+			);
 
-		let results = await this.database.updateAndGet(sql`
-			UPDATE ${new QueryIdentifier(this.table)}
-			SET ${SqlQuery.join(fieldQueries, sql`, `)}
-			WHERE ${new QueryIdentifier(this.primaryKey)} = ${(<any>model)[this.primaryKey]}
-		`);
-
-		if (results === null) {
-			// TODO need a sequence between those queries
-			results = await this.database.query(sql`
-				SELECT *
-				FROM ${new QueryIdentifier(this.table)}
-				WHERE ${new QueryIdentifier(this.primaryKey)} = ${(<any>model)[this.primaryKey]};
+			let results = await sequenceDb.updateAndGet(sql`
+				UPDATE ${new QueryIdentifier(this.table)}
+				SET ${SqlQuery.join(fieldQueries, sql`, `)}
+				WHERE ${new QueryIdentifier(this.primaryKey)} = ${(<any>model)[this.primaryKey]}
 			`);
 
-			if (results.length === 0) {
-				throw new NotFoundError(`Object not found in table ${this.table} after update (got ${this.primaryKey} = ${(<any>model)[this.primaryKey]})`);
+			if (results === null) {
+				results = await sequenceDb.query(sql`
+					SELECT *
+					FROM ${new QueryIdentifier(this.table)}
+					WHERE ${new QueryIdentifier(this.primaryKey)} = ${(<any>model)[this.primaryKey]};
+				`);
+
+				if (results.length === 0) {
+					throw new NotFoundError(`Object not found in table ${this.table} after update (got ${this.primaryKey} = ${(<any>model)[this.primaryKey]})`);
+				}
+
+				const newModel = await this.createModelFromAttributes(model);
+				Object.assign(newModel, results[0]);
+				return newModel;
+			} else {
+				if (results.length === 0) {
+					throw new NotFoundError(`Object not found in table ${this.table} for ${this.primaryKey} = ${(<any>model)[this.primaryKey]}`);
+				}
+				if (results.length > 1) {
+					throw new TooManyResultsError(`Multiple objects found in table ${this.table} for ${this.primaryKey} = ${(<any>model)[this.primaryKey]}`);
+				}
 			}
 
 			const newModel = await this.createModelFromAttributes(model);
 			Object.assign(newModel, results[0]);
 			return newModel;
-		} else {
-			if (results.length === 0) {
-				throw new NotFoundError(`Object not found in table ${this.table} for ${this.primaryKey} = ${(<any>model)[this.primaryKey]}`);
-			}
-			if (results.length > 1) {
-				throw new TooManyResultsError(`Multiple objects found in table ${this.table} for ${this.primaryKey} = ${(<any>model)[this.primaryKey]}`);
-			}
-		}
-
-		const newModel = await this.createModelFromAttributes(model);
-		Object.assign(newModel, results[0]);
-		return newModel;
+		});
 	}
 
 	public async delete(model: Model) {


### PR DESCRIPTION
- [x] Move the non-standard SQL used by the repository to the db class
- [x] #7 needs to be fixed so the `sequence` can properly be used in the two modified repository methods
- [x] Properly use the `sequence` in the two modified repository methods
- [x] Need to unit test the two new methods of the db class
- [x] Need to unit test the repository behaviour in cases where the records are not returned by `insertAndGet` and `updateAndGet`

Once merged, it closes #19 and will also allow to implement #3.